### PR TITLE
[SSD-41] db 테이블 생성

### DIFF
--- a/backend/src/main/java/com/timepaper/backend/domain/postit/entity/Postit.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/entity/Postit.java
@@ -3,6 +3,7 @@ package com.timepaper.backend.domain.postit.entity;
 import com.timepaper.backend.domain.timepaper.entity.TimePaper;
 import com.timepaper.backend.domain.user.entity.User;
 import com.timepaper.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -33,6 +34,10 @@ public class Postit extends BaseTimeEntity {
   @JoinColumn(name = "author_id", nullable = false)
   private User author;
 
+  @Column(length = 20, nullable = false)
+  private String authorName;
+
+  @Column(length = 155)
   private String content;
 
   private String imageUrl;

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/entity/Postit.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/entity/Postit.java
@@ -1,0 +1,40 @@
+package com.timepaper.backend.domain.postit.entity;
+
+import com.timepaper.backend.domain.timepaper.entity.Timepaper;
+import com.timepaper.backend.domain.user.entity.User;
+import com.timepaper.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "postits")
+public class Postit extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "timepaper_id", nullable = false)
+  private Timepaper timepaper;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "author_id", nullable = false)
+  private User author;
+
+  private String content;
+  
+  private String imageUrl;
+
+}

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/entity/Postit.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/entity/Postit.java
@@ -1,6 +1,6 @@
 package com.timepaper.backend.domain.postit.entity;
 
-import com.timepaper.backend.domain.timepaper.entity.Timepaper;
+import com.timepaper.backend.domain.timepaper.entity.TimePaper;
 import com.timepaper.backend.domain.user.entity.User;
 import com.timepaper.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Entity;
@@ -26,15 +26,15 @@ public class Postit extends BaseTimeEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "timepaper_id", nullable = false)
-  private Timepaper timepaper;
+  @JoinColumn(name = "time_paper_id", nullable = false)
+  private TimePaper timePaper;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "author_id", nullable = false)
   private User author;
 
   private String content;
-  
+
   private String imageUrl;
 
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/TimePaper.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/TimePaper.java
@@ -19,8 +19,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "timepapers")
-public class Timepaper extends BaseTimeEntity {
+@Table(name = "time_papers")
+public class TimePaper extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/TimePaper.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/TimePaper.java
@@ -30,7 +30,7 @@ public class TimePaper extends BaseTimeEntity {
   @JoinColumn(name = "creator_id", nullable = false)
   private User creator;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 30)
   private String title;
 
   private String recipientEmail;

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/Timepaper.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/Timepaper.java
@@ -1,0 +1,40 @@
+package com.timepaper.backend.domain.timepaper.entity;
+
+import com.timepaper.backend.domain.user.entity.User;
+import com.timepaper.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "timepapers")
+public class Timepaper extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "creator_id", nullable = false)
+  private User creator;
+
+  @Column(nullable = false)
+  private String title;
+
+  private String recipientEmail;
+
+  private LocalDateTime releaseDate;
+
+}

--- a/backend/src/main/java/com/timepaper/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/user/entity/User.java
@@ -1,0 +1,34 @@
+package com.timepaper.backend.domain.user.entity;
+
+import com.timepaper.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users",
+    uniqueConstraints = @UniqueConstraint(columnNames = "email")
+)
+public class User extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false)
+  private String password;
+
+
+}

--- a/backend/src/main/java/com/timepaper/backend/global/config/JpaConfig.java
+++ b/backend/src/main/java/com/timepaper/backend/global/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.timepaper.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/backend/src/main/java/com/timepaper/backend/global/entity/BaseTimeEntity.java
+++ b/backend/src/main/java/com/timepaper/backend/global/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.timepaper.backend.global.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+}


### PR DESCRIPTION
# asap 

## 🔍 관련 Jira 이슈

- SSD-41

## 📝 변경 사항

- JPA Auditing 설정 및 공통 필드 관리를 위한 BaseTimeEntity 구현
  - createdAt, updatedAt 필드의 자동 관리를 위한 JPA Auditing 활성화

- 테이블 설계에 따른 기본 엔티티 구현
  - User 엔티티 생성 (이메일 unique 제약조건 추가)
  - TimePaper 엔티티 생성 및 User와의 연관관계 매핑
  - Postit 엔티티 생성 및 TimePaper, User와의 연관관계 매핑

- 코드 품질 개선
  - 엔티티명 일관성을 위한 Timepaper → TimePaper 변경
  - 성능 최적화를 위한 연관관계 Lazy 로딩 적용


## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항

- ERD의 FK 컬럼명 변경 관련 검토 요청
   - 기존 ERD의 모든 FK가 user_id로 통일되어 있어 각 테이블에서의 역할 구분이 모호합니다.
   - 각 테이블에서의 fk 역할을 명확히 표현하기 위해 다음과 같이 변경했습니다.
   - time_papers 테이블 : user_id -> creator_id
   - postits 테이블 : user_id -> author_id
   
   - 변경사항 검토 부탁드립니다. 