### PR TITLE
[SSD-75] api 요청에 대한 jwt 인증 처리

### DIFF
--- a/backend/src/main/java/com/timepaper/backend/domain/user/controller/TestController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/user/controller/TestController.java
@@ -38,4 +38,16 @@ public class TestController {
     return "테스트 통과";
   }
 
+  @RequestMapping("/timepapers/postit")
+  @GetMapping
+  public String publicTest() {
+    return "public 경로 요청 테스트";
+  }
+
+  @RequestMapping("/timepapers")
+  @PostMapping
+  public String forbiddenTest() {
+    return "test";
+  }
+
 }

--- a/backend/src/main/java/com/timepaper/backend/global/auth/jwt/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/timepaper/backend/global/auth/jwt/handler/CustomAccessDeniedHandler.java
@@ -7,26 +7,24 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @RequiredArgsConstructor
 @Component
-public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
   private final ObjectMapper objectMapper;
 
   @Override
-  public void commence(HttpServletRequest request, HttpServletResponse response,
-      AuthenticationException authException) throws IOException, ServletException {
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
     response.setContentType("application/json;charset=UTF-8");
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 
-    ApiResponse<Void> errorResponse = ApiResponse.error("JWT 토큰이 유효하지 않습니다.", "3001");
+    ApiResponse<Void> errorResponse = ApiResponse.error("접근 권한이 없습니다.", "3002");
     response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
   }
 }

--- a/backend/src/main/java/com/timepaper/backend/global/auth/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/timepaper/backend/global/auth/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.timepaper.backend.global.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timepaper.backend.global.dto.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    ApiResponse<Void> errorResponse = ApiResponse.error("JWT 토큰이 만료되었거나 변조되었습니다.", "3001");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/backend/src/main/java/com/timepaper/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/timepaper/backend/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.timepaper.backend.global.auth.jwt.filter.LoginFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -31,7 +32,8 @@ public class SecurityConfig {
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/api/auth/login", "/api/auth/signup").permitAll()
+            .requestMatchers(HttpMethod.GET, SecurityPathConfig.PUBLIC_GET_URLS).permitAll()
+            .requestMatchers(HttpMethod.POST, SecurityPathConfig.PUBLIC_POST_URLS).permitAll()
             .anyRequest().authenticated()
         )
         .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/timepaper/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/timepaper/backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.timepaper.backend.global.config;
 
 import com.timepaper.backend.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.timepaper.backend.global.auth.jwt.filter.LoginFilter;
+import com.timepaper.backend.global.auth.jwt.handler.CustomAccessDeniedHandler;
 import com.timepaper.backend.global.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ public class SecurityConfig {
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final LoginFilter loginFilter;
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  private final CustomAccessDeniedHandler accessDeniedHandler;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -41,7 +43,9 @@ public class SecurityConfig {
         .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(exception -> exception
-            .authenticationEntryPoint(jwtAuthenticationEntryPoint));
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            .accessDeniedHandler(accessDeniedHandler)
+        );
 
     return http.build();
   }

--- a/backend/src/main/java/com/timepaper/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/timepaper/backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.timepaper.backend.global.config;
 
 import com.timepaper.backend.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.timepaper.backend.global.auth.jwt.filter.LoginFilter;
+import com.timepaper.backend.global.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final LoginFilter loginFilter;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -37,7 +39,9 @@ public class SecurityConfig {
             .anyRequest().authenticated()
         )
         .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
-        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exception -> exception
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint));
 
     return http.build();
   }

--- a/backend/src/main/java/com/timepaper/backend/global/config/SecurityPathConfig.java
+++ b/backend/src/main/java/com/timepaper/backend/global/config/SecurityPathConfig.java
@@ -1,0 +1,16 @@
+package com.timepaper.backend.global.config;
+
+public class SecurityPathConfig {
+
+  public static final String[] PUBLIC_GET_URLS = {
+      "/api/timepapers/**"
+  };
+
+  public static final String[] PUBLIC_POST_URLS = {
+      "/api/auth/login",
+      "/api/auth/signup",
+      "/api/auth/email-verification-codes",
+      "/api/auth/email-verification-codes/validate"
+  };
+
+}


### PR DESCRIPTION
# asap 

## 🔍 관련 Jira 이슈

- SSD-75

## 📝 변경 사항

- 인증/비인증 API 설정
- JWT 토큰 만료 및 변조 시 HTTP 상태코드 401, 메시지 정의  로직 구현

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항

Confluence 개발 문서/API 응답 코드 및 메시지 구조 정의서에 반영해놨습니다. 