### PR TITLE
[SSD-85] 포스트잇 조회, 삭제 api 구현

### DIFF
--- a/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
@@ -63,6 +63,6 @@ public class PostitController {
   ) {
     postitService.deletePostit(postitId, user.getId());
     return ResponseEntity.status(HttpStatus.NO_CONTENT)
-               .body(ApiResponse.ok("포스트잇 생성 성공", "SUCCESS", null));
+               .body(ApiResponse.ok("포스트잇 삭제 성공", "NO_CONTENT", null));
   }
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
@@ -5,12 +5,14 @@ import com.timepaper.backend.domain.postit.service.PostitService;
 import com.timepaper.backend.domain.user.entity.User;
 import com.timepaper.backend.global.dto.ApiResponse;
 import jakarta.validation.Valid;
+import java.awt.print.Pageable;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +38,13 @@ public class PostitController {
     postitService.createPostit(UUID.fromString(timePaperId), user, requestDto, image);
     return ResponseEntity.status(HttpStatus.CREATED)
                .body(ApiResponse.ok("포스트잇 생성 성공", "SUCCESS", null));
+  }
+
+  @GetMapping("timepapers/{timePaperId}/postits")
+  public void getPostit(
+      @PathVariable String timePaperId,
+      Pageable pageable
+  ) {
+
   }
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
@@ -1,14 +1,15 @@
 package com.timepaper.backend.domain.postit.controller;
 
 import com.timepaper.backend.domain.postit.dto.PostitCreateRequestDto;
+import com.timepaper.backend.domain.postit.dto.PostitListResponseDto;
 import com.timepaper.backend.domain.postit.service.PostitService;
 import com.timepaper.backend.domain.user.entity.User;
 import com.timepaper.backend.global.dto.ApiResponse;
 import jakarta.validation.Valid;
-import java.awt.print.Pageable;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -41,10 +42,16 @@ public class PostitController {
   }
 
   @GetMapping("timepapers/{timePaperId}/postits")
-  public void getPostit(
+  public ResponseEntity<ApiResponse<PostitListResponseDto>> getPostit(
       @PathVariable String timePaperId,
       Pageable pageable
   ) {
-
+    return ResponseEntity.ok(
+        ApiResponse.ok(
+            "조회 성공",
+            "SUCCESS",
+            postitService.getPostit(UUID.fromString(timePaperId), pageable)
+        )
+    );
   }
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/controller/PostitController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,5 +54,15 @@ public class PostitController {
             postitService.getPostit(UUID.fromString(timePaperId), pageable)
         )
     );
+  }
+
+  @DeleteMapping("postits/{postitId}")
+  public ResponseEntity<ApiResponse<Void>> deletePostit(
+      @PathVariable Long postitId,
+      @AuthenticationPrincipal User user
+  ) {
+    postitService.deletePostit(postitId, user.getId());
+    return ResponseEntity.status(HttpStatus.NO_CONTENT)
+               .body(ApiResponse.ok("포스트잇 생성 성공", "SUCCESS", null));
   }
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitListResponseDto.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitListResponseDto.java
@@ -1,4 +1,5 @@
-import com.timepaper.backend.domain.postit.dto.PostitResponseDto;
+package com.timepaper.backend.domain.postit.dto;
+
 import com.timepaper.backend.domain.postit.entity.Postit;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitListResponseDto.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitListResponseDto.java
@@ -1,0 +1,26 @@
+import com.timepaper.backend.domain.postit.dto.PostitResponseDto;
+import com.timepaper.backend.domain.postit.entity.Postit;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+public class PostitListResponseDto {
+
+  private List<PostitResponseDto> postits;
+  private Boolean hasNext;
+
+  public static PostitListResponseDto from(Page<Postit> postitPage) {
+    List<PostitResponseDto> postitDtos = postitPage.getContent().stream()
+                                             .map(PostitResponseDto::from)
+                                             .collect(Collectors.toList());
+
+    return PostitListResponseDto.builder()
+               .postits(postitDtos)
+               .hasNext(postitPage.hasNext())
+               .build();
+  }
+}

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitResponseDto.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitResponseDto.java
@@ -1,0 +1,32 @@
+package com.timepaper.backend.domain.postit.dto;
+
+import com.timepaper.backend.domain.postit.entity.Postit;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+public class PostitResponseDto {
+
+  private Long postitId;
+  private String author;
+  private Long authorId;
+  private String content;
+  private LocalDateTime createdAt;
+  private String imageUrl;
+  private Boolean hasNext;
+
+  PostitResponseDto from(Postit postit, Page<Postit> postitPage) {
+    return PostitResponseDto.builder()
+               .postitId(postit.getId())
+               .author(postit.getAuthorName())
+               .authorId(postit.getAuthor().getId())
+               .content(postit.getContent())
+               .createdAt(postit.getCreatedAt())
+               .imageUrl(postit.getImageUrl())
+               .hasNext(postitPage.hasNext())
+               .build();
+  }
+}

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitResponseDto.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitResponseDto.java
@@ -16,7 +16,7 @@ public class PostitResponseDto {
   private LocalDateTime createdAt;
   private String imageUrl;
 
-  public PostitResponseDto from(Postit postit) {
+  public static PostitResponseDto from(Postit postit) {
     return PostitResponseDto.builder()
                .postitId(postit.getId())
                .author(postit.getAuthorName())

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitResponseDto.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/dto/PostitResponseDto.java
@@ -4,7 +4,6 @@ import com.timepaper.backend.domain.postit.entity.Postit;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Page;
 
 @Getter
 @Builder
@@ -16,9 +15,8 @@ public class PostitResponseDto {
   private String content;
   private LocalDateTime createdAt;
   private String imageUrl;
-  private Boolean hasNext;
 
-  PostitResponseDto from(Postit postit, Page<Postit> postitPage) {
+  public PostitResponseDto from(Postit postit) {
     return PostitResponseDto.builder()
                .postitId(postit.getId())
                .author(postit.getAuthorName())
@@ -26,7 +24,6 @@ public class PostitResponseDto {
                .content(postit.getContent())
                .createdAt(postit.getCreatedAt())
                .imageUrl(postit.getImageUrl())
-               .hasNext(postitPage.hasNext())
                .build();
   }
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/repository/PostitRepository.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/repository/PostitRepository.java
@@ -1,8 +1,12 @@
 package com.timepaper.backend.domain.postit.repository;
 
 import com.timepaper.backend.domain.postit.entity.Postit;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostitRepository extends JpaRepository<Postit, Long> {
 
+  Page<Postit> findAllByTimePaperId(UUID timePaperId, Pageable pageable);
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/service/PostitService.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/service/PostitService.java
@@ -57,4 +57,20 @@ public class PostitService {
 
     return PostitListResponseDto.from(postitsPage);
   }
+
+  @Transactional
+  public void deletePostit(Long postitId, Long userId) {
+    Postit postit = postitRepository.findById(postitId)
+                        .orElseThrow(() -> new IllegalArgumentException("포스트잇이 없습니다."));
+
+    if (postit.getAuthor().getId() != userId) {
+      throw new IllegalArgumentException("삭제 권한이 없습니다");
+    }
+
+    if (postit.getS3Key() != null) {
+      s3Service.deleteFile(postit.getS3Key());
+    }
+
+    postitRepository.delete(postit);
+  }
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/postit/service/PostitService.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/postit/service/PostitService.java
@@ -1,6 +1,7 @@
 package com.timepaper.backend.domain.postit.service;
 
 import com.timepaper.backend.domain.postit.dto.PostitCreateRequestDto;
+import com.timepaper.backend.domain.postit.dto.PostitListResponseDto;
 import com.timepaper.backend.domain.postit.entity.Postit;
 import com.timepaper.backend.domain.postit.repository.PostitRepository;
 import com.timepaper.backend.domain.timepaper.entity.TimePaper;
@@ -11,6 +12,8 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,7 +48,13 @@ public class PostitService {
                               .orElseThrow(() -> new IllegalArgumentException());
 
     Postit postit = requestDto.toEntity(timePaper, user, s3Key, s3ImageUrl);
-    
+
     postitRepository.save(postit);
+  }
+
+  public PostitListResponseDto getPostit(UUID timePaperId, Pageable pageable) {
+    Page<Postit> postitsPage = postitRepository.findAllByTimePaperId(timePaperId, pageable);
+
+    return PostitListResponseDto.from(postitsPage);
   }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,3 +11,9 @@ jwt.secret=${JWT_SECRET}
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.password=${REDIS_PASSWORD}
+# ???? ??? ???
+spring.servlet.multipart.max-file-size=3MB
+spring.servlet.multipart.max-request-size=5MB
+# ?????? ???
+spring.data.web.pageable.max-page-size=10
+spring.data.web.pageable.default-page-size=10


### PR DESCRIPTION
# asap 

## 🔍 관련 Jira 이슈

- SSD-85

## 📝 변경 사항
- 포스트잇 조회 api 구현
- 포스트잇 삭제 api 구현
- 이미지 업로드 사이즈, 페이지네이션 기본값, 최대치 설정
```
# 멀티파트 이미지 사이즈
spring.servlet.multipart.max-file-size=3MB
spring.servlet.multipart.max-request-size=5MB
# 페이지네이션 기본값
spring.data.web.pageable.max-page-size=10
spring.data.web.pageable.default-page-size=10
```

## 조회 요청 형식
```
/postits?page=0&size=5
```

## 응답 형식
```java
{
    "message": "조회 성공",
    "code": "SUCCESS",
    "data": {
        "postits": [
            {
                "postitId": 1,
                "author": "dsadsa",
                "authorId": 1,
                "content": "안녕핫십니까~~~",
                "createdAt": "2025-02-26T21:38:51.591925",
                "imageUrl": "dsadsadsa"
            },
            {
                "postitId": 2,
                "author": "dsadsa",
                "authorId": 1,
                "content": "안녕핫십니까~~~",
                "createdAt": "2025-02-26T21:38:53.080972",
                "imageUrl": "dsadsadsa"
            }
        ],
        "hasNext": true
    }
}
```
- hasNext는 인피니티 스크롤할 때 다음 페이지가 없다면 요청을 안보내게끔 처리하기 위해 내려줍니다.
- 응답에 타임페이퍼 id, 페이지 불필요해보여 수정했습니다.
- 작성자 아이디는 포스트잇 삭제 버튼 노출할 때 비교값으로 사용해야될 것 같아서 내려줍니다.

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항
- 삭제의 경우는 요청 url이 달라서 컨트롤러 단에서 한번에 묶지 않았습니다. 추후에 url 수정하면 변경하겠습니다.
