### PR TITLE
[SSD-87]타임페이퍼 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/controller/TimePaperController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/controller/TimePaperController.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,6 +48,16 @@ public class TimePaperController {
             .ok("타임페이퍼 조회 성공",
                 "OK",
                 responseDto));
+  }
+
+  @DeleteMapping("/{timepaperId}")
+  public ResponseEntity<ApiResponse<Void>> deleteTimePaper(@PathVariable UUID timepaperId) {
+    timePaperService.deleteTimePaper(timepaperId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        .body(ApiResponse
+            .ok("타임페이퍼 삭제 성공",
+                "NO_CONTENT",
+                null));
   }
 
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/service/TimePaperService.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/service/TimePaperService.java
@@ -38,12 +38,18 @@ public class TimePaperService {
     return TimePaperResponseDto.from(timePaper);
   }
 
-  @Transactional(readOnly = true)
   public TimePaperResponseDto readTimePaperById(UUID timepaperId) {
 
     TimePaper timePaper = timePaperRepository.findById(timepaperId)
-        .orElseThrow(() -> new IllegalArgumentException("타임페이퍼를 찾을 수 없습니다."));
+        .orElseThrow(() -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
     return TimePaperResponseDto.from(timePaper);
+  }
+
+  @Transactional
+  public void deleteTimePaper(UUID timepaperId) {
+    TimePaper timePaper = timePaperRepository.findById(timepaperId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
+    timePaperRepository.delete(timePaper);
   }
 
 }


### PR DESCRIPTION
- 타임페이퍼 삭제 기능 구현

# asap 

## 🔍 관련 Jira 이슈

- SSD-87

## 📝 변경 사항

- 타임페이퍼 삭제 기능 구현
- 타임페이퍼 서비스 단에서 불필요한 @Transactional 제거

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

