### PR TITLE
[SSD-100] 루트 헤더 구현

### DIFF
--- a/frontend/src/assets/images/arrowBackIcon.svg
+++ b/frontend/src/assets/images/arrowBackIcon.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="20px" viewBox="0 0 11 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>arrow_back_ios</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Rounded" transform="translate(-548.000000, -3434.000000)">
+            <g id="Navigation" transform="translate(100.000000, 3378.000000)">
+                <g id="-Round-/-Navigation-/-arrow_back_ios" transform="translate(442.000000, 54.000000)">
+                    <g>
+                        <polygon id="Path" opacity="0.87" points="0 0 24 0 24 24 0 24"></polygon>
+                        <path d="M16.62,2.99 C16.13,2.5 15.34,2.5 14.85,2.99 L6.54,11.3 C6.15,11.69 6.15,12.32 6.54,12.71 L14.85,21.02 C15.34,21.51 16.13,21.51 16.62,21.02 C17.11,20.53 17.11,19.74 16.62,19.25 L9.38,12 L16.63,4.75 C17.11,4.27 17.11,3.47 16.62,2.99 Z" id="🔹-Icon-Color" fill="#1D1D1D"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/frontend/src/components/RootHeader.jsx
+++ b/frontend/src/components/RootHeader.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function RootHeader() {
-  return <div>RootHeader</div>;
-}

--- a/frontend/src/components/rootheader/RootHeader.jsx
+++ b/frontend/src/components/rootheader/RootHeader.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import styles from './RootHeader.module.css';
+import images from '../../constant/staticImagePath';
+
+export default function RootHeader() {
+  const navigate = useNavigate();
+  const title = useSelector((state) => state.header.pageTitle);
+
+  return (
+    <div className={styles.header}>
+      <button className={styles.backButton} onClick={() => navigate(-1)}>
+        <img src={images.arrowBackIcon} alt="뒤로가기" />
+      </button>
+      <h1 className={styles.title}>{title}</h1>
+      <button className={styles.backButton} onClick={() => navigate('/')}>
+        <img src={images.homeIcon} alt="홈 버튼" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/rootheader/RootHeader.module.css
+++ b/frontend/src/components/rootheader/RootHeader.module.css
@@ -1,0 +1,20 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+}
+
+.backButton {
+  font-size: 16px;
+  color: #333;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: bold;
+  color: #333;
+}

--- a/frontend/src/components/rootheader/RootHeader.module.css
+++ b/frontend/src/components/rootheader/RootHeader.module.css
@@ -17,4 +17,8 @@
   font-size: 18px;
   font-weight: bold;
   color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 50%;
 }

--- a/frontend/src/constant/staticImagePath.js
+++ b/frontend/src/constant/staticImagePath.js
@@ -1,11 +1,12 @@
-import timepaperLogo from '../assets/images/timepaperLogo.png'
-import postitAfternoon from '../assets/images/postitAfternoon.svg'
-import postitNight from '../assets/images/postitNight.svg'
-import notFound from '../assets/images/notFound.svg'
-import dropDownIcon from '../assets/images/dropDownIcon.svg'
-import homeIcon from '../assets/images/homeIcon.svg'
-import imageSelectIcon from '../assets/images/imageSelectIcon.svg'
-import timeCapsule from '../assets/images/timecapsule.png'
+import timepaperLogo from '../assets/images/timepaperLogo.png';
+import postitAfternoon from '../assets/images/postitAfternoon.svg';
+import postitNight from '../assets/images/postitNight.svg';
+import notFound from '../assets/images/notFound.svg';
+import dropDownIcon from '../assets/images/dropDownIcon.svg';
+import homeIcon from '../assets/images/homeIcon.svg';
+import imageSelectIcon from '../assets/images/imageSelectIcon.svg';
+import timeCapsule from '../assets/images/timecapsule.png';
+import arrowBackIcon from '../assets/images/arrowBackIcon.svg';
 
 export default {
   timepaperLogo,
@@ -15,5 +16,6 @@ export default {
   timeCapsule,
   dropDownIcon,
   homeIcon,
-  imageSelectIcon
-}
+  imageSelectIcon,
+  arrowBackIcon,
+};

--- a/frontend/src/layout/HeaderLayout.jsx
+++ b/frontend/src/layout/HeaderLayout.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import RootHeader from '../components/RootHeader';
+import RootHeader from '../components/rootheader/RootHeader';
 
 export default function HeaderLayout() {
   return (

--- a/frontend/src/pages/timepaperDetail/TimePaperDetail.jsx
+++ b/frontend/src/pages/timepaperDetail/TimePaperDetail.jsx
@@ -7,7 +7,7 @@ import { setPageTitle } from '../../store/slices/headerSlice';
 const tempPostTimePaper = async (data) => {
   return new Promise((resolve) => {
     setTimeout(() => {
-      resolve({ title: '2022년도 졸업식' });
+      resolve({ title: '2022년도 졸업식입니다, 작별 인사를 남겨주세요.' });
     }, 1000);
   });
 };
@@ -81,7 +81,7 @@ export default function TimePaperDetail() {
   }, [timepaperId, dispatch]);
   return (
     <div className={styles.container}>
-      <h2>2022년도 졸업식</h2>
+      <h2>2022년도 졸업식입니다, 작별 인사를 남겨주세요.</h2>
 
       <ul className={styles.timepaperList}>
         {postIt.map((paper) => (

--- a/frontend/src/pages/timepaperDetail/TimePaperDetail.jsx
+++ b/frontend/src/pages/timepaperDetail/TimePaperDetail.jsx
@@ -1,10 +1,19 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styles from './timepaperdetail.module.css';
+import { useDispatch } from 'react-redux';
+import { setPageTitle } from '../../store/slices/headerSlice';
 
+const tempPostTimePaper = async (data) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ title: '2022년도 졸업식' });
+    }, 1000);
+  });
+};
 export default function TimePaperDetail() {
   const { timepaperId } = useParams();
-  const [timepapers, setTimepapers] = useState([
+  const [postIt, setPostIt] = useState([
     {
       id: 1,
       title: '감사합니다.',
@@ -56,13 +65,26 @@ export default function TimePaperDetail() {
       post: '/images/postitD.png',
     },
   ]);
+  const dispatch = useDispatch();
 
+  useEffect(() => {
+    const updateHeaderTitle = async () => {
+      try {
+        // 필요시 timepaperId 등 data를 전달합니다.
+        const data = await tempPostTimePaper({ timepaperId });
+        dispatch(setPageTitle(data.title)); // 전역 상태에 타이틀 업데이트
+      } catch (error) {
+        console.error('Error fetching timepaper data:', error);
+      }
+    };
+    updateHeaderTitle();
+  }, [timepaperId, dispatch]);
   return (
     <div className={styles.container}>
       <h2>2022년도 졸업식</h2>
 
       <ul className={styles.timepaperList}>
-        {timepapers.map((paper) => (
+        {postIt.map((paper) => (
           <li key={paper.id} className={styles.timepaperItem}>
             <h3>{paper.title}</h3>
             {/* 이미지 경로를 src 속성에 전달 */}

--- a/frontend/src/pages/timepapercreate/TimePaperCreate.jsx
+++ b/frontend/src/pages/timepapercreate/TimePaperCreate.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from './timePaperCreate.module.css';
 import BottomButton from '../../components/BottomButton/BottomButton';
 import UnderBarInput from '../../components/UnderBarInput/UnderBarInput';
-
+import { setPageTitle } from '../../store/slices/headerSlice';
+import { useDispatch } from 'react-redux';
 // 가짜 Api 함수
 const tempPostTimePaper = async (data) => {
   return new Promise((resolve) => {
@@ -18,6 +19,11 @@ export default function TimePaperCreate() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('제목을 입력해주세요.');
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setPageTitle('타임페이퍼 생성'));
+  }, [dispatch]);
 
   const navigate = useNavigate();
 

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -4,7 +4,7 @@ import Home from '../pages/home/Home';
 import Login from '../pages/login/Login.jsx';
 import Signup from '../pages/SignUp';
 import MyPage from '../pages/MyPage.jsx';
-import TimePaperDetail from '../pages/TimePaperDetail';
+import TimePaperDetail from '../pages/timepaperDetail/TimePaperDetail';
 import TimePaperIsLocked from '../pages/timepaperlocked/TimePaperIsLocked.jsx';
 import PostItCreate from '../pages/PostItCreate';
 import NotFound from '../pages/error/NotFound';

--- a/frontend/src/store/slices/headerSlice.js
+++ b/frontend/src/store/slices/headerSlice.js
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  pageTitle: " "
+}
+
+const headerSlice = createSlice({
+  name: 'header',
+  initialState,
+  reducers: {
+    setPageTitle(state, action) {
+      state.pageTitle = action.payload;
+    },
+  },
+});
+
+export const { setPageTitle } = headerSlice.actions;
+export default headerSlice.reducer;

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "./slices/authSlice";
+import headerReducer from './slices/headerSlice';
 
 const store = configureStore({
   reducer: {
-    auth: authReducer,    
+    auth: authReducer,
+    header: headerReducer,
   },
 });
 


### PR DESCRIPTION
# asap 

## 🔍 관련 Jira 이슈

- SSD-100

## 📝 변경 사항

- back, title,  home 으로 구성된 헤더 구현
- 헤더에 사용할 backIcon 추가
- TimePaperDetail 페이지에 테스트 용으로 가짜 api 함수 구현
    - 헤더 적용
- TimePaperCreate 페이지 헤더 적용

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/54cbef89-d15c-4231-b972-a5616a3e79a3)
![image](https://github.com/user-attachments/assets/50f706bd-3196-4a8d-85a4-68a671b965e2)
![image](https://github.com/user-attachments/assets/c419f443-5144-4d03-8ff0-f94585807229)

## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

- 각자 만든 페이지에 아래와 같은 형식으로 추가를 하면 해당 페이지에 대한 헤더 타이틀이 생깁니다.
- `import React, { useEffect } from 'react';` , `import { useDispatch } from 'react-redux';` , `import { setPageTitle } from '../store/slices/headerSlice';` 와 같이 **import 경로 주의** 해주시길 바랍니다. 
- setPageTitle("해당 페이지 이름") 에 넣고 새로 고침을 하면 헤더에 적용이 될 겁니다.
- 적용 후 PR 남겨주시길 바랍니다.
- 추후 CSS 수정이 있을 예정입니다.

```
import React, { useEffect } from 'react';
import { useDispatch } from 'react-redux';
import { setPageTitle } from '../store/slices/headerSlice';

export default function SignUp() {
  const dispatch = useDispatch();

  useEffect(() => {
    dispatch(setPageTitle('회원가입'));
  }, [dispatch]);
  return <div>SignUp</div>;
}
```

