### PR TITLE
[SSD-103] 타임페이퍼 잠금 페이지 API 연동

### DIFF
--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/controller/TimePaperController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/controller/TimePaperController.java
@@ -5,6 +5,7 @@ import com.timepaper.backend.domain.timepaper.dto.request.TimePaperLockRequestDt
 import com.timepaper.backend.domain.timepaper.dto.response.TimePaperLockResponseDto;
 import com.timepaper.backend.domain.timepaper.dto.response.TimePaperResponseDto;
 import com.timepaper.backend.domain.timepaper.service.TimePaperService;
+import com.timepaper.backend.domain.user.entity.User;
 import com.timepaper.backend.global.dto.ApiResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -69,11 +71,12 @@ public class TimePaperController {
   @PatchMapping("/{timePaperId}/lock")
   public ResponseEntity<ApiResponse<TimePaperLockResponseDto>> lockTimePaper(
       @PathVariable UUID timePaperId,
-      @RequestBody TimePaperLockRequestDto timePaperLockRequestDto
+      @RequestBody TimePaperLockRequestDto timePaperLockRequestDto,
+      @AuthenticationPrincipal User requester
   ) {
 
     TimePaperLockResponseDto responseDto = timePaperService.lockTimePaper(timePaperId,
-        timePaperLockRequestDto);
+        timePaperLockRequestDto, requester.getId());
     return ResponseEntity.status(HttpStatus.OK)
                .body(ApiResponse.ok("타임페이퍼 잠금 처리 성공", "OK", responseDto));
   }

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/controller/TimePaperController.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/controller/TimePaperController.java
@@ -6,7 +6,6 @@ import com.timepaper.backend.domain.timepaper.dto.response.TimePaperLockResponse
 import com.timepaper.backend.domain.timepaper.dto.response.TimePaperResponseDto;
 import com.timepaper.backend.domain.timepaper.service.TimePaperService;
 import com.timepaper.backend.global.dto.ApiResponse;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,39 +38,44 @@ public class TimePaperController {
         timePaperService.createTimePaper(timePaperCreateRequestDto, authentication);
 
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(ApiResponse
-            .ok("타임페이퍼 생성 성공",
-                "CREATED",
-                responseDto));
+               .body(ApiResponse
+                         .ok("타임페이퍼 생성 성공",
+                             "CREATED",
+                             responseDto));
   }
 
   @GetMapping("/{timepaperId}")
-  public ResponseEntity<ApiResponse<TimePaperResponseDto>> readTimePaperById(@PathVariable UUID timepaperId) {
+  public ResponseEntity<ApiResponse<TimePaperResponseDto>> readTimePaperById(
+      @PathVariable UUID timepaperId) {
 
     TimePaperResponseDto responseDto = timePaperService.readTimePaperById(timepaperId);
     return ResponseEntity.status(HttpStatus.OK)
-        .body(ApiResponse
-            .ok("타임페이퍼 조회 성공",
-                "OK",
-                responseDto));
+               .body(ApiResponse
+                         .ok("타임페이퍼 조회 성공",
+                             "OK",
+                             responseDto));
   }
 
   @DeleteMapping("/{timepaperId}")
   public ResponseEntity<ApiResponse<Void>> deleteTimePaper(@PathVariable UUID timepaperId) {
     timePaperService.deleteTimePaper(timepaperId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT)
-        .body(ApiResponse
-            .ok("타임페이퍼 삭제 성공",
-                "NO_CONTENT",
-                null));
+               .body(ApiResponse
+                         .ok("타임페이퍼 삭제 성공",
+                             "NO_CONTENT",
+                             null));
   }
 
-  @PatchMapping("/{timepaperId}/lock")
-  public ResponseEntity<ApiResponse<TimePaperLockResponseDto>> lockTimePaper(@PathVariable UUID timepaperId, @RequestBody TimePaperLockRequestDto timePaperLockRequestDto) {
+  @PatchMapping("/{timePaperId}/lock")
+  public ResponseEntity<ApiResponse<TimePaperLockResponseDto>> lockTimePaper(
+      @PathVariable UUID timePaperId,
+      @RequestBody TimePaperLockRequestDto timePaperLockRequestDto
+  ) {
 
-    TimePaperLockResponseDto responseDto = timePaperService.lockTimePaper(timepaperId, timePaperLockRequestDto);
+    TimePaperLockResponseDto responseDto = timePaperService.lockTimePaper(timePaperId,
+        timePaperLockRequestDto);
     return ResponseEntity.status(HttpStatus.OK)
-        .body(ApiResponse.ok("타임페이퍼 잠금 처리 성공", "OK", responseDto));
+               .body(ApiResponse.ok("타임페이퍼 잠금 처리 성공", "OK", responseDto));
   }
 
 }

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/TimePaper.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/entity/TimePaper.java
@@ -41,8 +41,6 @@ public class TimePaper extends BaseTimeEntity {
 
   private LocalDateTime releaseDate;
 
-  private boolean isLocked;
-
   @Builder
   public TimePaper(User creator, String title, String recipientEmail) {
     this.creator = creator;

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/service/TimePaperService.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/service/TimePaperService.java
@@ -29,7 +29,7 @@ public class TimePaperService {
     String creatorEmail = authentication.getName();
 
     User creator = (User) userRepository.findByEmail(creatorEmail)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                              .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
     TimePaper timePaper = timePaperRepository.save(
         TimePaper.builder()
@@ -43,23 +43,28 @@ public class TimePaperService {
   public TimePaperResponseDto readTimePaperById(UUID timepaperId) {
 
     TimePaper timePaper = timePaperRepository.findById(timepaperId)
-        .orElseThrow(() -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
+                              .orElseThrow(
+                                  () -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
     return TimePaperResponseDto.from(timePaper);
   }
 
   @Transactional
   public void deleteTimePaper(UUID timepaperId) {
     TimePaper timePaper = timePaperRepository.findById(timepaperId)
-        .orElseThrow(() -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
+                              .orElseThrow(
+                                  () -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
     timePaperRepository.delete(timePaper);
   }
 
   @Transactional
-  public TimePaperLockResponseDto lockTimePaper(UUID timepaperId, TimePaperLockRequestDto timePaperLockRequestDto) {
+  public TimePaperLockResponseDto lockTimePaper(UUID timePaperId,
+      TimePaperLockRequestDto timePaperLockRequestDto) {
 
-    TimePaper timePaper = timePaperRepository.findById(timepaperId)
-        .orElseThrow(() -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
-    timePaper.setReleaseDate(timePaperLockRequestDto.getRecipientEmail(), timePaperLockRequestDto.getReleaseDate());
+    TimePaper timePaper = timePaperRepository.findById(timePaperId)
+                              .orElseThrow(
+                                  () -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
+    timePaper.setReleaseDate(timePaperLockRequestDto.getRecipientEmail(),
+        timePaperLockRequestDto.getReleaseDate());
     return TimePaperLockResponseDto.from(timePaper);
   }
 

--- a/backend/src/main/java/com/timepaper/backend/domain/timepaper/service/TimePaperService.java
+++ b/backend/src/main/java/com/timepaper/backend/domain/timepaper/service/TimePaperService.java
@@ -57,12 +57,20 @@ public class TimePaperService {
   }
 
   @Transactional
-  public TimePaperLockResponseDto lockTimePaper(UUID timePaperId,
-      TimePaperLockRequestDto timePaperLockRequestDto) {
+  public TimePaperLockResponseDto lockTimePaper(
+      UUID timePaperId,
+      TimePaperLockRequestDto timePaperLockRequestDto,
+      Long requesterId
+  ) {
 
     TimePaper timePaper = timePaperRepository.findById(timePaperId)
                               .orElseThrow(
                                   () -> new IllegalArgumentException("해당 타임페이퍼를 찾을 수 없습니다."));
+
+    if (!timePaper.getCreator().getId().equals(requesterId)) {
+      throw new IllegalArgumentException("잠금 권한이 없습니다.");
+    }
+
     timePaper.setReleaseDate(timePaperLockRequestDto.getRecipientEmail(),
         timePaperLockRequestDto.getReleaseDate());
     return TimePaperLockResponseDto.from(timePaper);

--- a/backend/src/main/java/com/timepaper/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/timepaper/backend/global/config/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
         .allowedOrigins("http://localhost:5173", origin) //임시 배포시 변경
-        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
         .allowedHeaders("*")
         .allowCredentials(true)
         .exposedHeaders("Authorization")

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,5 +17,4 @@ spring.servlet.multipart.max-request-size=5MB
 # ?????? ???
 spring.data.web.pageable.max-page-size=10
 spring.data.web.pageable.default-page-size=10
-
 origin=${DOMAIN}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
 import './css/index.css';
-import { Provider, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { login } from './store/slices/authSlice';
 import { api } from './api/api';
 

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -69,8 +69,13 @@ export const api = {
     const response = await apiInstance.delete(`/timepapers/${timepaperId}`)
   },
 
-  lockTimepaper: async (timepaperId) => { 
-    const response = await apiInstance.patch(`/timepapers/${timepaperId}/lock`)
+  lockTimepaper: async (timepaperId, email, releaseDate) => { 
+    const response = await apiInstance.patch(`/timepapers/${timepaperId}/lock`, {
+      recipientEmail: email,
+      releaseDate: releaseDate
+    })
+
+    return lockTimepaper
   },
 
   getPostits: async (timepaperId) => { 

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -75,7 +75,7 @@ export const api = {
       releaseDate: releaseDate
     })
 
-    return lockTimepaper
+    return response
   },
 
   getPostits: async (timepaperId) => { 

--- a/frontend/src/api/apiInstance.js
+++ b/frontend/src/api/apiInstance.js
@@ -35,7 +35,6 @@ apiInstance.interceptors.response.use(
   async (error) => {
     const response = error.response;
     if (response.data?.code === 3001) {
-      console.log(response.data.code)
       try {
         const response = await api.reissue();
         const accessToken = response.headers.authorization;

--- a/frontend/src/pages/timepapersetlocked/TimePaperSetLock.jsx
+++ b/frontend/src/pages/timepapersetlocked/TimePaperSetLock.jsx
@@ -61,7 +61,7 @@ export default function TimePaperSetLock() {
   }, [email, releaseDate]);
 
   if (!location.state?.authorEmail) {
-    // return <Navigate to="/404" replace />;
+    return <Navigate to="/404" replace />;
   }
 
   return (

--- a/frontend/src/pages/timepapersetlocked/TimePaperSetLock.jsx
+++ b/frontend/src/pages/timepapersetlocked/TimePaperSetLock.jsx
@@ -1,27 +1,24 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams, useLocation, Navigate } from 'react-router-dom';
 import styles from './timePaperSetLock.module.css';
 import BottomButton from '../../components/BottomButton/BottomButton';
 import UnderBarInput from '../../components/UnderBarInput/UnderBarInput';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
-
-const tempTimePaperSetLock = async (data) => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ id: 'dummyId' });
-    }, 1000);
-  });
-};
+import { api } from '../../api/api';
+import { useSelector } from 'react-redux';
 
 export default function TimePaperSetLock() {
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('제목을 입력해주세요.');
-  const [releaseDate, setReleaseDate] = useState(new Date());
-
+  const [releaseDate, setReleaseDate] = useState(null);
+  const [isLoginButtonEnable, setIsLoginButtonEnable] = useState(false);
+  const { timepaperId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+
   const regEmail =
     /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
 
@@ -38,31 +35,38 @@ export default function TimePaperSetLock() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setIsLoginButtonEnable(false);
 
-    if (!email.trim() || !regEmail.test(email)) {
-      setError(true);
-      setErrorMessage('올바른 이메일 형식을 입력해 주세요.');
-      return;
-    }
-
-    setError(false);
     setLoading(true);
 
     try {
-      const response = await tempTimePaperSetLock({ email, releaseDate });
-      navigate(`/timepaper/${response.id}`);
+      const response = await api.lockTimepaper(timepaperId, email, releaseDate);
+      navigate(`/timepaper/${response.id}/lock`, { replace: true });
     } catch (err) {
       console.error(err);
       setError(true);
       setErrorMessage('타임페이퍼 캡슐화 중 오류가 발생했습니다.');
     } finally {
       setLoading(false);
+      setIsLoginButtonEnable(true);
     }
   };
 
+  useEffect(() => {
+    if (!error && email.trim().length !== 0 && releaseDate !== null) {
+      setIsLoginButtonEnable(true);
+    } else {
+      setIsLoginButtonEnable(false);
+    }
+  }, [email, releaseDate]);
+
+  if (!location.state?.authorEmail) {
+    // return <Navigate to="/404" replace />;
+  }
+
   return (
     <>
-      <form onSubmit={handleSubmit}>
+      <form>
         <div className={styles.container}>
           <div className={styles.inputContainer}>
             <p>알림 받을 수신자 이메일</p>
@@ -93,6 +97,7 @@ export default function TimePaperSetLock() {
           <BottomButton
             title={loading ? '시간 자물쇠 거는 중...' : '타임페이퍼 캡슐화'}
             onClick={handleSubmit}
+            isEnable={isLoginButtonEnable}
           />
         </div>
       </form>

--- a/frontend/src/pages/timepapersetlocked/TimePaperSetLock.jsx
+++ b/frontend/src/pages/timepapersetlocked/TimePaperSetLock.jsx
@@ -6,7 +6,8 @@ import UnderBarInput from '../../components/UnderBarInput/UnderBarInput';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { api } from '../../api/api';
-import { useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
+import { setPageTitle } from '../../store/slices/headerSlice';
 
 export default function TimePaperSetLock() {
   const [email, setEmail] = useState('');
@@ -18,6 +19,7 @@ export default function TimePaperSetLock() {
   const { timepaperId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
+  const dispatch = useDispatch();
 
   const regEmail =
     /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
@@ -59,6 +61,10 @@ export default function TimePaperSetLock() {
       setIsLoginButtonEnable(false);
     }
   }, [email, releaseDate]);
+
+  useEffect(() => {
+    dispatch(setPageTitle('타임캡슐 생성'));
+  }, []);
 
   if (!location.state?.authorEmail) {
     return <Navigate to="/404" replace />;

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -16,7 +16,7 @@ const router = createBrowserRouter([
   {
     path: '/',
     element: <RootLayout />,
-    // errorElement: <NotFound />,
+    errorElement: <NotFound />,
     children: [
       {
         index: true,


### PR DESCRIPTION
# asap 

## 🔍 관련 Jira 이슈

- SSD-103

## 📝 변경 사항
- (BE) CORS설정 PATCH 메서드 추가
- (BE) 요청 보내는 유저와 타임페이퍼 작성자랑 같은 유저인지 예외처리
- (FE) lock 페이지 api 연동

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항
- url을 통해 해당 페이지에 들어오는 사용자를 처리하기 위해서 navigate할 떄 state로 authorEmail을 전달하지 않으면 NotFound 페이지로 라우팅하게끔 만들었습니다.
```
if (!location.state?.authorEmail) {
    return <Navigate to="/404" replace />;
  }
```
테스트할 떄 해당 부분 주석처리 또는 navigate 호출시 state 전달해야 합니다.
