### PR TITLE
[SSD-108] 타임페이퍼 조회 api 연동

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -55,6 +55,7 @@ export const api = {
 
   getTimepaper: async (timepaperId) => {
     const response = await apiInstance.get(`/timepapers/${timepaperId}`)
+    return response;
   },
 
   createTimepaper: async (title) => {
@@ -75,6 +76,7 @@ export const api = {
 
   getPostits: async (timepaperId) => { 
     const response = await apiInstance.get(`/timepapers/${timepaperId}/postits`)
+    return response;
   },
 
   createPostit: async (timepaperId, author, content, image) => { 

--- a/frontend/src/pages/timepaperDetail/timepaperdetail.module.css
+++ b/frontend/src/pages/timepaperDetail/timepaperdetail.module.css
@@ -1,10 +1,10 @@
 /* styles.css */
 .container {
   text-align: center; /* 전체 콘텐츠 가운데 정렬 */
+  padding: 20px; /* 컨테이너 내부 여백 추가 */
 }
 
-
- .timepaperList {
+.timepaperList {
   display: flex;
   flex-wrap: wrap; /* 줄바꿈 허용 */
   justify-content: center; /* 항목을 가운데 정렬 */
@@ -12,7 +12,6 @@
   padding: 0;
   list-style-type: none; /* 리스트 스타일 제거 */
 }
- 
 
 .timepaperList {
   display: grid;
@@ -28,9 +27,56 @@
   align-items: center; /* 제목과 이미지를 가운데 정렬 */
 }
 
-.timepaperItem img {
-  width: 131px; /* 이미지 크기 설정 */
-  height: auto;
+.postitBackground {
+  width: 100%;
+  height: 200px;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  overflow: auto;
+  /* text-overflow: ellipsis; */
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.postitContent {
+  font-size: 14px;
+  text-align: left;
+  word-break: break-word;
+}
+/* Webkit 기반 브라우저 (Chrome, Edge, Safari)용 스크롤바 스타일 */
+.overlay::-webkit-scrollbar {
+  width: 10px; /* 스크롤바 너비 */
+}
+
+.overlay::-webkit-scrollbar-track {
+  background: #f1f1f1; /* 스크롤 트랙 배경색 */
+}
+
+.overlay::-webkit-scrollbar-thumb {
+  background-color: #888; /* 스크롤 thumb 색상 */
+  border-radius: 10px; /* 둥근 모서리 */
+}
+
+.overlay::-webkit-scrollbar-thumb:hover {
+  background-color: #d87728; /* hover 시 thumb 색상 */
+}
+
+/* Firefox 브라우저용 스크롤바 스타일 */
+.overlay {
+  scrollbar-width: thin; /* 스크롤바 너비를 얇게 설정 */
+  scrollbar-color: var(--orange-color) #f1f1f1; /* thumb 색상과 트랙 배경색 설정 */
 }
 
 .addButton {


### PR DESCRIPTION
# asap 

## 🔍 관련 Jira 이슈

- SSD-108

## 📝 변경 사항

- api에 return 추가
- 타임페이퍼의 제목을 불러올 조회 API 연동
- 해당 타임페이퍼의 포스트잇들을 불러올 조회 API 연동

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/833c2685-574c-4e74-b2c6-b904352b3d39)

![image](https://github.com/user-attachments/assets/8966c485-856c-40c8-8a4a-3a51c2827e58)


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항


